### PR TITLE
Add new capability if not undefined

### DIFF
--- a/framework_patches/nightwatchPatch.js
+++ b/framework_patches/nightwatchPatch.js
@@ -8,7 +8,9 @@ exports.nightwatchPatch = function() {
   };
   return {
     addCapability: function(key, value) {
-      patchOptions['desiredCapabilities'][key] = value;
+      if (value !== undefined) {
+        patchOptions['desiredCapabilities'][key] = value;
+      }
     },
     seleniumHost: function(host, port) {
       patchOptions['seleniumHost'] = host;


### PR DESCRIPTION
Test case:

1. Specify `os` and `os_version` in `desiredCapabilities`, for example:

        [...]
        "firefox" : {
            "desiredCapabilities": {
                "browserName" : "Firefox",
                "version" : "50.0",
                "os": "Windows",
                "os_version": "10",
                "resolution": "1024x768"
            }
        },
        [...]

Expected:
`os` and `os_version` are passed to BrowserStack.

Actual:
`os` and `os_version` are overwritten by:

* https://github.com/tomasz-oponowicz/browserstack-integration-nodejs/blob/master/browserstack.js#L42 [and]
* https://github.com/tomasz-oponowicz/browserstack-integration-nodejs/blob/master/browserstack.js#L43

...even when `BSTACK_*` aren't defined.